### PR TITLE
Spotify account api module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# Secrets
+Secrets.plist

--- a/Sources/App/SideProjectSpotifyApp/SideProjectSpotifyApp.xcodeproj/project.pbxproj
+++ b/Sources/App/SideProjectSpotifyApp/SideProjectSpotifyApp.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2430DE5226B1E0AF00D7763F /* SpotifyAccountApiModule.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2430DE5126B1E0AF00D7763F /* SpotifyAccountApiModule.framework */; };
+		2430DE5326B1E0AF00D7763F /* SpotifyAccountApiModule.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2430DE5126B1E0AF00D7763F /* SpotifyAccountApiModule.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2446F4FA26B07D6D00A67703 /* SpotifyAppDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2446F4F926B07D6D00A67703 /* SpotifyAppDependencies.swift */; };
 		2446F4FE26B082A400A67703 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2446F4FD26B082A400A67703 /* MainViewModel.swift */; };
 		2446F50226B08C3200A67703 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2446F50126B08C3200A67703 /* MainTabBarController.swift */; };
@@ -49,6 +51,7 @@
 			files = (
 				2482E35226A60D01003E070D /* SpotifyApiModule.framework in Embed Frameworks */,
 				2482E34E26A60CFE003E070D /* NetworkingService.framework in Embed Frameworks */,
+				2430DE5326B1E0AF00D7763F /* SpotifyAccountApiModule.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -56,6 +59,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2430DE5126B1E0AF00D7763F /* SpotifyAccountApiModule.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SpotifyAccountApiModule.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2446F4F926B07D6D00A67703 /* SpotifyAppDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyAppDependencies.swift; sourceTree = "<group>"; };
 		2446F4FD26B082A400A67703 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		2446F50126B08C3200A67703 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
@@ -83,6 +87,7 @@
 			files = (
 				2482E35126A60D01003E070D /* SpotifyApiModule.framework in Frameworks */,
 				2482E34D26A60CFE003E070D /* NetworkingService.framework in Frameworks */,
+				2430DE5226B1E0AF00D7763F /* SpotifyAccountApiModule.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -201,6 +206,7 @@
 		2482E34B26A60CFE003E070D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				2430DE5126B1E0AF00D7763F /* SpotifyAccountApiModule.framework */,
 				2482E35026A60D01003E070D /* SpotifyApiModule.framework */,
 				2482E34C26A60CFE003E070D /* NetworkingService.framework */,
 			);

--- a/Sources/App/SideProjectSpotifyApp/SideProjectSpotifyApp.xcodeproj/project.pbxproj
+++ b/Sources/App/SideProjectSpotifyApp/SideProjectSpotifyApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2446F4FA26B07D6D00A67703 /* SpotifyAppDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2446F4F926B07D6D00A67703 /* SpotifyAppDependencies.swift */; };
 		2446F4FE26B082A400A67703 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2446F4FD26B082A400A67703 /* MainViewModel.swift */; };
 		2446F50226B08C3200A67703 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2446F50126B08C3200A67703 /* MainTabBarController.swift */; };
+		2459E21126B2B27900F08FEB /* Secrets in Resources */ = {isa = PBXBuildFile; fileRef = 2459E21026B2B27900F08FEB /* Secrets */; };
 		24677D2B26A1B42200540181 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24677D2A26A1B42200540181 /* AppDelegate.swift */; };
 		24677D2D26A1B42200540181 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24677D2C26A1B42200540181 /* SceneDelegate.swift */; };
 		24677D2F26A1B42200540181 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24677D2E26A1B42200540181 /* ViewController.swift */; };
@@ -63,6 +64,7 @@
 		2446F4F926B07D6D00A67703 /* SpotifyAppDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyAppDependencies.swift; sourceTree = "<group>"; };
 		2446F4FD26B082A400A67703 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		2446F50126B08C3200A67703 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
+		2459E21026B2B27900F08FEB /* Secrets */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Secrets; sourceTree = "<group>"; };
 		24677D2726A1B42200540181 /* SideProjectSpotifyApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SideProjectSpotifyApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		24677D2A26A1B42200540181 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		24677D2C26A1B42200540181 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 		2446F4F826B07CCC00A67703 /* Main */ = {
 			isa = PBXGroup;
 			children = (
+				2459E20F26B2B25E00F08FEB /* Resources */,
 				2446F4FF26B08C0A00A67703 /* Common */,
 				2446F4FB26B0824800A67703 /* Scenes */,
 				2446F4F926B07D6D00A67703 /* SpotifyAppDependencies.swift */,
@@ -149,6 +152,14 @@
 				2446F50126B08C3200A67703 /* MainTabBarController.swift */,
 			);
 			path = UI;
+			sourceTree = "<group>";
+		};
+		2459E20F26B2B25E00F08FEB /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				2459E21026B2B27900F08FEB /* Secrets */,
+			);
+			path = Resources;
 			sourceTree = "<group>";
 		};
 		24677D1E26A1B42200540181 = {
@@ -317,6 +328,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2459E21126B2B27900F08FEB /* Secrets in Resources */,
 				24677D3726A1B42500540181 /* LaunchScreen.storyboard in Resources */,
 				24677D3426A1B42500540181 /* Assets.xcassets in Resources */,
 			);

--- a/Sources/App/SideProjectSpotifyApp/SideProjectSpotifyApp/Main/Resources/Secrets/README.md
+++ b/Sources/App/SideProjectSpotifyApp/SideProjectSpotifyApp/Main/Resources/Secrets/README.md
@@ -1,0 +1,6 @@
+# Secrets
+- Add a file named "Secrets.plist" under the Secrets resource folder.
+- Add the keys for the secrets the app needs:
+    SPOTIFY_CLIENT_ID
+    SPOTIFY_CLIENT_SECRET
+- The Secrets.plist filename is already added to the .gitignore so that this was won't be committed to the repository.

--- a/Sources/App/SideProjectSpotifyApp/SideProjectSpotifyApp/Main/SpotifyAppDependencies.swift
+++ b/Sources/App/SideProjectSpotifyApp/SideProjectSpotifyApp/Main/SpotifyAppDependencies.swift
@@ -51,7 +51,18 @@ class SpotifyAppDependencies {
     }
     
     func start() {
-        setRootViewController(makeMainTabBarController())
+        
+        accountService.getApiToken { result in
+            switch result {
+            case let .failure(error):
+                print(error)
+            case let .success(tokenDTO):
+                self.service.setAccessToken(SpotifyApiModule.AccessTokenDTO(accessToken: tokenDTO.accessToken,
+                                                                            tokenType: tokenDTO.tokenType,
+                                                                            expiresIn: tokenDTO.expiresIn))
+            }
+        }
+        self.setRootViewController(self.makeMainTabBarController())
     }
     
     func makeMainViewController() -> UIViewController {

--- a/Sources/App/SideProjectSpotifyApp/SideProjectSpotifyApp/Main/SpotifyAppDependencies.swift
+++ b/Sources/App/SideProjectSpotifyApp/SideProjectSpotifyApp/Main/SpotifyAppDependencies.swift
@@ -52,6 +52,11 @@ class SpotifyAppDependencies {
     
     func start() {
         
+        //TODO: show a loading screen... 
+        let vc = UIViewController()
+        vc.view.backgroundColor = .white
+        setRootViewController(vc)
+        
         accountService.getApiToken { result in
             switch result {
             case let .failure(error):
@@ -60,9 +65,12 @@ class SpotifyAppDependencies {
                 self.service.setAccessToken(SpotifyApiModule.AccessTokenDTO(accessToken: tokenDTO.accessToken,
                                                                             tokenType: tokenDTO.tokenType,
                                                                             expiresIn: tokenDTO.expiresIn))
+                DispatchQueue.main.async {
+                    self.setRootViewController(self.makeMainTabBarController())
+                }
+                
             }
         }
-        self.setRootViewController(self.makeMainTabBarController())
     }
     
     func makeMainViewController() -> UIViewController {

--- a/Sources/App/SideProjectSpotifyApp/SideProjectSpotifyApp/Main/SpotifyAppDependencies.swift
+++ b/Sources/App/SideProjectSpotifyApp/SideProjectSpotifyApp/Main/SpotifyAppDependencies.swift
@@ -8,6 +8,7 @@
 import Foundation
 import NetworkingService
 import SpotifyApiModule
+import SpotifyAccountApiModule
 import UIKit
 
 // THIS IS THE APP COMPOSITION ROOT
@@ -23,7 +24,18 @@ class SpotifyAppDependencies {
     }()
     
     private lazy var service: SpotifyApiService = {
-        return SpotifyApiRemote(url: URL(string: "https://api.spotify.com/v1")!, client: client, accessToken: AccessTokenDTO(accessToken: "BQCtrbDNVESQ0cMeZjvXIIXS5rGAUdmzcLPIi7_uNpLCMGMhXnA3sVvGXjuqm0idAwwc7S9LTm0kfQEEn6s", tokenType: "Bearer", expiresIn: 3600))
+        return SpotifyApiRemote(url: URL(string: "https://api.spotify.com/v1")!,
+                                client: client,
+                                accessToken: AccessTokenDTO(accessToken: "BQCtrbDNVESQ0cMeZjvXIIXS5rGAUdmzcLPIi7_uNpLCMGMhXnA3sVvGXjuqm0idAwwc7S9LTm0kfQEEn6s",
+                                                            tokenType: "Bearer",
+                                                            expiresIn: 3600))
+    }()
+    
+    private lazy var accountService: SpotifyAccountApiService = {
+        return SpotifyAccountApiRemote(url: URL(string: "https://accounts.spotify.com/api")!,
+                                       client: client,
+                                       clientID: spotifyAccountClientID,
+                                       clientSecret: spotifyAccountClientSecret)
     }()
     
     public func setScene(_ scene: UIScene) {
@@ -88,4 +100,76 @@ class ViewControllerRouter: ViewControllerRouting {
     }
 }
 
+// SECRETS
 
+extension SpotifyAppDependencies {
+    
+    internal var spotifyAccountClientID: String {
+      get {
+        // 1 - search for the secrets plist file
+        let name = "Secrets/Secrets"
+        let fileExt = "plist"
+        let key = "SPOTIFY_CLIENT_ID"
+        let missing = "SPOTIFY_CLIENT_ID-NOT-FOUND"
+        let notDefined = "SPOTIFY_CLIENT_ID-NOT-VALID"
+        
+        return searchSecretValueFor(key: key,
+                                    in: name,
+                                    with: fileExt,
+                                    missingErrorMessageKey: missing,
+                                    noteDefinedErrorMessageKey: notDefined)
+      }
+    }
+    
+    internal var spotifyAccountClientSecret: String {
+      get {
+        // 1 - search for the secrets plist file
+        let name = "Secrets/Secrets"
+        let fileExt = "plist"
+        let key = "SPOTIFY_CLIENT_SECRET"
+        let missing = "SPOTIFY_CLIENT_SECRET-NOT-FOUND"
+        let notDefined = "SPOTIFY_CLIENT_SECRET-NOT-VALID"
+        
+        return searchSecretValueFor(key: key,
+                                    in: name,
+                                    with: fileExt,
+                                    missingErrorMessageKey: missing,
+                                    noteDefinedErrorMessageKey: notDefined)
+      }
+    }
+    
+    func searchSecretValueFor(key: String,
+                              in name: String,
+                              with fileExt: String,
+                              missingErrorMessageKey: String,
+                              noteDefinedErrorMessageKey: String) -> String {
+        
+        guard let url = Bundle.main.url(
+                    forResource: name,
+                    withExtension: fileExt
+                ) else {
+                    print("Couldn't find file '\(name).\(fileExt)'.")
+                    return missingErrorMessageKey
+                }
+//        guard let filePath = Bundle.main.path(forResource: "Secrets-Info", ofType: "plist") else {
+//          //fatalError("Couldn't find file 'Secrets.plist'.")
+//            print("Couldn't find file 'Secrets.plist'.")
+//            return "COOKING_API_KEY-NOT-FOUND"
+//        }
+//        // 2
+//        let plist = NSDictionary(contentsOfFile: filePath)
+        let plist = NSDictionary(contentsOf: url)
+        guard let value = plist?.object(forKey: key) as? String else {
+          //fatalError("Couldn't find key 'COOKING_API_KEY' in 'Secrets-Info.plist'.")
+            print("Couldn't find key '\(key)' in '\(name).\(fileExt)'.")
+            return missingErrorMessageKey
+        }
+        // 3
+        if (value.isEmpty || value.starts(with: "_") || value.starts(with: " ") ) {
+
+            print("Value not defined for '\(key)' in '\(name).\(fileExt)'.")
+            return noteDefinedErrorMessageKey
+        }
+        return value
+    }
+}

--- a/Sources/Modules/NetworkingService/NetworkingService/HTTPClient.swift
+++ b/Sources/Modules/NetworkingService/NetworkingService/HTTPClient.swift
@@ -17,6 +17,7 @@ public protocol HTTPClient {
     var urlQueryParameters: HTTPClientEntity { get set }
     var httpBodyParameters: HTTPClientEntity { get set }
     
+    func clearRequest()
     
     @discardableResult
     func makeRequest(toURL url: URL,
@@ -77,6 +78,10 @@ public struct HTTPClientEntity {
     
     public func totalItems() -> Int {
         return values.count
+    }
+    
+    public mutating func removeAll() {
+        values.removeAll()
     }
 }
 

--- a/Sources/Modules/NetworkingService/NetworkingService/URLSessionHTTPClient.swift
+++ b/Sources/Modules/NetworkingService/NetworkingService/URLSessionHTTPClient.swift
@@ -46,7 +46,7 @@ public class URLSessionHTTPClient: HTTPClient {
             
             let bodyString = httpBodyParameters
                 .allValues()
-                .map { "\($0)=\(String(describing: $1.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)))" }
+                .map { "\($0)=\(String(describing: $1.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!))" }
                 .joined(separator: "&")
             return bodyString.data(using: .utf8)
             
@@ -93,6 +93,14 @@ public class URLSessionHTTPClient: HTTPClient {
         
         request.httpBody = httpBody
         return request
+    }
+    
+    public func clearRequest() {
+        requestHttpHeaders.removeAll()
+        urlQueryParameters.removeAll()
+        httpBodyParameters.removeAll()
+        
+        httpBody = nil
     }
     
     public func makeRequest(toURL url: URL,

--- a/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule.xcodeproj/project.pbxproj
+++ b/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule.xcodeproj/project.pbxproj
@@ -1,0 +1,331 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2492F6C126B18B9B00AD1C4F /* SpotifyAccountApiModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 2492F6BF26B18B9B00AD1C4F /* SpotifyAccountApiModule.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		2492F6BC26B18B9B00AD1C4F /* SpotifyAccountApiModule.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SpotifyAccountApiModule.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2492F6BF26B18B9B00AD1C4F /* SpotifyAccountApiModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpotifyAccountApiModule.h; sourceTree = "<group>"; };
+		2492F6C026B18B9B00AD1C4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		2492F6B926B18B9B00AD1C4F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		2492F6B226B18B9B00AD1C4F = {
+			isa = PBXGroup;
+			children = (
+				2492F6BE26B18B9B00AD1C4F /* SpotifyAccountApiModule */,
+				2492F6BD26B18B9B00AD1C4F /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		2492F6BD26B18B9B00AD1C4F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				2492F6BC26B18B9B00AD1C4F /* SpotifyAccountApiModule.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		2492F6BE26B18B9B00AD1C4F /* SpotifyAccountApiModule */ = {
+			isa = PBXGroup;
+			children = (
+				2492F6BF26B18B9B00AD1C4F /* SpotifyAccountApiModule.h */,
+				2492F6C026B18B9B00AD1C4F /* Info.plist */,
+			);
+			path = SpotifyAccountApiModule;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		2492F6B726B18B9B00AD1C4F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2492F6C126B18B9B00AD1C4F /* SpotifyAccountApiModule.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		2492F6BB26B18B9B00AD1C4F /* SpotifyAccountApiModule */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2492F6C426B18B9B00AD1C4F /* Build configuration list for PBXNativeTarget "SpotifyAccountApiModule" */;
+			buildPhases = (
+				2492F6B726B18B9B00AD1C4F /* Headers */,
+				2492F6B826B18B9B00AD1C4F /* Sources */,
+				2492F6B926B18B9B00AD1C4F /* Frameworks */,
+				2492F6BA26B18B9B00AD1C4F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SpotifyAccountApiModule;
+			productName = SpotifyAccountApiModule;
+			productReference = 2492F6BC26B18B9B00AD1C4F /* SpotifyAccountApiModule.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		2492F6B326B18B9B00AD1C4F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1250;
+				TargetAttributes = {
+					2492F6BB26B18B9B00AD1C4F = {
+						CreatedOnToolsVersion = 12.5;
+					};
+				};
+			};
+			buildConfigurationList = 2492F6B626B18B9B00AD1C4F /* Build configuration list for PBXProject "SpotifyAccountApiModule" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 2492F6B226B18B9B00AD1C4F;
+			productRefGroup = 2492F6BD26B18B9B00AD1C4F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				2492F6BB26B18B9B00AD1C4F /* SpotifyAccountApiModule */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		2492F6BA26B18B9B00AD1C4F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2492F6B826B18B9B00AD1C4F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		2492F6C226B18B9B00AD1C4F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		2492F6C326B18B9B00AD1C4F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		2492F6C526B18B9B00AD1C4F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = SpotifyAccountApiModule/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = de.test.SpotifyAccountApiModule;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		2492F6C626B18B9B00AD1C4F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = SpotifyAccountApiModule/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = de.test.SpotifyAccountApiModule;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2492F6B626B18B9B00AD1C4F /* Build configuration list for PBXProject "SpotifyAccountApiModule" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2492F6C226B18B9B00AD1C4F /* Debug */,
+				2492F6C326B18B9B00AD1C4F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2492F6C426B18B9B00AD1C4F /* Build configuration list for PBXNativeTarget "SpotifyAccountApiModule" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2492F6C526B18B9B00AD1C4F /* Debug */,
+				2492F6C626B18B9B00AD1C4F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 2492F6B326B18B9B00AD1C4F /* Project object */;
+}

--- a/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule.xcodeproj/project.pbxproj
+++ b/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule.xcodeproj/project.pbxproj
@@ -7,10 +7,31 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2430DE4326B1C96E00D7763F /* SpotifyAccountApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2430DE4226B1C96E00D7763F /* SpotifyAccountApiService.swift */; };
+		2430DE4826B1C9FA00D7763F /* NetworkingService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2430DE4726B1C9FA00D7763F /* NetworkingService.framework */; };
+		2430DE4926B1C9FA00D7763F /* NetworkingService.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2430DE4726B1C9FA00D7763F /* NetworkingService.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		2430DE4D26B1CA2900D7763F /* AccessTokenDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2430DE4C26B1CA2900D7763F /* AccessTokenDTO.swift */; };
 		2492F6C126B18B9B00AD1C4F /* SpotifyAccountApiModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 2492F6BF26B18B9B00AD1C4F /* SpotifyAccountApiModule.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		2430DE4A26B1C9FA00D7763F /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				2430DE4926B1C9FA00D7763F /* NetworkingService.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		2430DE4226B1C96E00D7763F /* SpotifyAccountApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyAccountApiService.swift; sourceTree = "<group>"; };
+		2430DE4726B1C9FA00D7763F /* NetworkingService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = NetworkingService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2430DE4C26B1CA2900D7763F /* AccessTokenDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenDTO.swift; sourceTree = "<group>"; };
 		2492F6BC26B18B9B00AD1C4F /* SpotifyAccountApiModule.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SpotifyAccountApiModule.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2492F6BF26B18B9B00AD1C4F /* SpotifyAccountApiModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpotifyAccountApiModule.h; sourceTree = "<group>"; };
 		2492F6C026B18B9B00AD1C4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -21,17 +42,35 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2430DE4826B1C9FA00D7763F /* NetworkingService.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2430DE4626B1C9FA00D7763F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				2430DE4726B1C9FA00D7763F /* NetworkingService.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		2430DE4B26B1CA1700D7763F /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				2430DE4C26B1CA2900D7763F /* AccessTokenDTO.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		2492F6B226B18B9B00AD1C4F = {
 			isa = PBXGroup;
 			children = (
 				2492F6BE26B18B9B00AD1C4F /* SpotifyAccountApiModule */,
 				2492F6BD26B18B9B00AD1C4F /* Products */,
+				2430DE4626B1C9FA00D7763F /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -46,8 +85,10 @@
 		2492F6BE26B18B9B00AD1C4F /* SpotifyAccountApiModule */ = {
 			isa = PBXGroup;
 			children = (
+				2430DE4B26B1CA1700D7763F /* Model */,
 				2492F6BF26B18B9B00AD1C4F /* SpotifyAccountApiModule.h */,
 				2492F6C026B18B9B00AD1C4F /* Info.plist */,
+				2430DE4226B1C96E00D7763F /* SpotifyAccountApiService.swift */,
 			);
 			path = SpotifyAccountApiModule;
 			sourceTree = "<group>";
@@ -74,6 +115,7 @@
 				2492F6B826B18B9B00AD1C4F /* Sources */,
 				2492F6B926B18B9B00AD1C4F /* Frameworks */,
 				2492F6BA26B18B9B00AD1C4F /* Resources */,
+				2430DE4A26B1C9FA00D7763F /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -94,6 +136,7 @@
 				TargetAttributes = {
 					2492F6BB26B18B9B00AD1C4F = {
 						CreatedOnToolsVersion = 12.5;
+						LastSwiftMigration = 1250;
 					};
 				};
 			};
@@ -130,6 +173,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2430DE4326B1C96E00D7763F /* SpotifyAccountApiService.swift in Sources */,
+				2430DE4D26B1CA2900D7763F /* AccessTokenDTO.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -261,6 +306,7 @@
 		2492F6C526B18B9B00AD1C4F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -276,6 +322,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = de.test.SpotifyAccountApiModule;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -284,6 +331,7 @@
 		2492F6C626B18B9B00AD1C4F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule.xcodeproj/project.pbxproj
+++ b/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2430DE4826B1C9FA00D7763F /* NetworkingService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2430DE4726B1C9FA00D7763F /* NetworkingService.framework */; };
 		2430DE4926B1C9FA00D7763F /* NetworkingService.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2430DE4726B1C9FA00D7763F /* NetworkingService.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2430DE4D26B1CA2900D7763F /* AccessTokenDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2430DE4C26B1CA2900D7763F /* AccessTokenDTO.swift */; };
+		2430DE5026B1DEA800D7763F /* SpotifyAccountApiRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2430DE4F26B1DEA800D7763F /* SpotifyAccountApiRemote.swift */; };
 		2492F6C126B18B9B00AD1C4F /* SpotifyAccountApiModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 2492F6BF26B18B9B00AD1C4F /* SpotifyAccountApiModule.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
@@ -32,6 +33,7 @@
 		2430DE4226B1C96E00D7763F /* SpotifyAccountApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyAccountApiService.swift; sourceTree = "<group>"; };
 		2430DE4726B1C9FA00D7763F /* NetworkingService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = NetworkingService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2430DE4C26B1CA2900D7763F /* AccessTokenDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenDTO.swift; sourceTree = "<group>"; };
+		2430DE4F26B1DEA800D7763F /* SpotifyAccountApiRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyAccountApiRemote.swift; sourceTree = "<group>"; };
 		2492F6BC26B18B9B00AD1C4F /* SpotifyAccountApiModule.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SpotifyAccountApiModule.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2492F6BF26B18B9B00AD1C4F /* SpotifyAccountApiModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SpotifyAccountApiModule.h; sourceTree = "<group>"; };
 		2492F6C026B18B9B00AD1C4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -65,6 +67,14 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		2430DE4E26B1DE4C00D7763F /* Remote */ = {
+			isa = PBXGroup;
+			children = (
+				2430DE4F26B1DEA800D7763F /* SpotifyAccountApiRemote.swift */,
+			);
+			path = Remote;
+			sourceTree = "<group>";
+		};
 		2492F6B226B18B9B00AD1C4F = {
 			isa = PBXGroup;
 			children = (
@@ -85,6 +95,7 @@
 		2492F6BE26B18B9B00AD1C4F /* SpotifyAccountApiModule */ = {
 			isa = PBXGroup;
 			children = (
+				2430DE4E26B1DE4C00D7763F /* Remote */,
 				2430DE4B26B1CA1700D7763F /* Model */,
 				2492F6BF26B18B9B00AD1C4F /* SpotifyAccountApiModule.h */,
 				2492F6C026B18B9B00AD1C4F /* Info.plist */,
@@ -173,6 +184,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2430DE5026B1DEA800D7763F /* SpotifyAccountApiRemote.swift in Sources */,
 				2430DE4326B1C96E00D7763F /* SpotifyAccountApiService.swift in Sources */,
 				2430DE4D26B1CA2900D7763F /* AccessTokenDTO.swift in Sources */,
 			);
@@ -314,6 +326,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SpotifyAccountApiModule/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -339,6 +352,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SpotifyAccountApiModule/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule/Info.plist
+++ b/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule/Model/AccessTokenDTO.swift
+++ b/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule/Model/AccessTokenDTO.swift
@@ -1,0 +1,30 @@
+//
+//  AccessTokenDTO.swift
+//  SpotifyAccountApiModule
+//
+//  Created by Christian Slanzi on 28.07.21.
+//
+
+import NetworkingService
+
+public struct AccessTokenDTO: DTO {
+    public var accessToken: String
+    public var tokenType: String
+    public var expiresIn: Int
+    
+    public init(accessToken: String, tokenType: String, expiresIn: Int) {
+        self.accessToken = accessToken
+        self.tokenType = tokenType
+        self.expiresIn = expiresIn
+    }
+    
+    public var description: String {
+        return """
+        ------------
+        accessToken = \(accessToken)
+        tokenType = \(tokenType)
+        expiresIn = \(expiresIn)
+        ------------
+        """
+    }
+}

--- a/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule/Remote/SpotifyAccountApiRemote.swift
+++ b/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule/Remote/SpotifyAccountApiRemote.swift
@@ -1,0 +1,52 @@
+//
+//  SpotifyAccountApiRemote.swift
+//  SpotifyAccountApiModule
+//
+//  Created by Christian Slanzi on 28.07.21.
+//
+
+import NetworkingService
+
+public class SpotifyAccountApiRemote: SpotifyAccountApiService {
+    
+    private var url: URL
+    private var client: HTTPClient
+    private var clientID: String
+    private var clientSecret: String
+
+    public init(url: URL, client: HTTPClient, clientID: String, clientSecret: String) {
+        self.url = url
+        self.client = client
+        self.clientID = clientID
+        self.clientSecret = clientSecret
+    }
+    
+    public func getApiToken(completion: @escaping (TokenResult) -> Void) {
+        let base64Encoded = "\(clientID):\(clientSecret)".toBase64()
+        client.requestHttpHeaders.add(value: "Basic \(base64Encoded)", forKey: "Authorization")
+        client.requestHttpHeaders.add(value: "application/x-www-form-urlencoded", forKey: "Content-Type")
+        client.httpBodyParameters.add(value: "client_credentials", forKey: "grant_type")
+        client.makeRequest(toURL: url.appendingPathComponent("token"), withHttpMethod: .post) { [weak self] result in
+                guard self != nil else { return }
+                
+                completion(GenericDecoder.decodeResult(result: result))
+        }
+    }
+}
+
+//TODO: move String extension to a Utils framework
+extension String {
+
+    func fromBase64() -> String? {
+        guard let data = Data(base64Encoded: self) else {
+            return nil
+        }
+
+        return String(data: data, encoding: .utf8)
+    }
+
+    func toBase64() -> String {
+        return Data(self.utf8).base64EncodedString()
+    }
+
+}

--- a/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule/SpotifyAccountApiModule.h
+++ b/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule/SpotifyAccountApiModule.h
@@ -1,0 +1,18 @@
+//
+//  SpotifyAccountApiModule.h
+//  SpotifyAccountApiModule
+//
+//  Created by Christian Slanzi on 28.07.21.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for SpotifyAccountApiModule.
+FOUNDATION_EXPORT double SpotifyAccountApiModuleVersionNumber;
+
+//! Project version string for SpotifyAccountApiModule.
+FOUNDATION_EXPORT const unsigned char SpotifyAccountApiModuleVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <SpotifyAccountApiModule/PublicHeader.h>
+
+

--- a/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule/SpotifyAccountApiService.swift
+++ b/Sources/Modules/SpotifyAccountApiModule/SpotifyAccountApiModule/SpotifyAccountApiService.swift
@@ -1,0 +1,16 @@
+//
+//  SpotifyAccountApiService.swift
+//  SpotifyAccountApiModule
+//
+//  Created by Christian Slanzi on 28.07.21.
+//
+
+import NetworkingService
+
+public protocol SpotifyAccountApiService {
+    typealias ServiceError = NetworkingServiceError
+    
+    typealias TokenResult = Swift.Result<AccessTokenDTO, ServiceError>
+
+    func getApiToken(completion: @escaping (TokenResult) -> Void)
+}

--- a/Sources/Modules/SpotifyApiModule/SpotifyApiModule.xcodeproj/project.pbxproj
+++ b/Sources/Modules/SpotifyApiModule/SpotifyApiModule.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		2482E33B26A6048C003E070D /* SpotifyApiModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 2482E33926A6048C003E070D /* SpotifyApiModule.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2482E34426A605C9003E070D /* SpotifyApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2482E34326A605C8003E070D /* SpotifyApiService.swift */; };
 		2482E34626A6086E003E070D /* AlbumsAnswerDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2482E34526A6086E003E070D /* AlbumsAnswerDTO.swift */; };
-		2482E34826A6090B003E070D /* SpotifyAccountRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2482E34726A6090B003E070D /* SpotifyAccountRemote.swift */; };
+		2482E34826A6090B003E070D /* SpotifyApiRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2482E34726A6090B003E070D /* SpotifyApiRemote.swift */; };
 		2482E34A26A60B20003E070D /* AccessTokenDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2482E34926A60B20003E070D /* AccessTokenDTO.swift */; };
 		2482E35626A622CE003E070D /* AlbumDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2482E35526A622CE003E070D /* AlbumDTO.swift */; };
 		847DE86126A9F2C800FF716B /* AlbumItemDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847DE86026A9F2C800FF716B /* AlbumItemDTO.swift */; };
@@ -52,7 +52,7 @@
 		2482E33A26A6048C003E070D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2482E34326A605C8003E070D /* SpotifyApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyApiService.swift; sourceTree = "<group>"; };
 		2482E34526A6086E003E070D /* AlbumsAnswerDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumsAnswerDTO.swift; sourceTree = "<group>"; };
-		2482E34726A6090B003E070D /* SpotifyAccountRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyAccountRemote.swift; sourceTree = "<group>"; };
+		2482E34726A6090B003E070D /* SpotifyApiRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyApiRemote.swift; sourceTree = "<group>"; };
 		2482E34926A60B20003E070D /* AccessTokenDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenDTO.swift; sourceTree = "<group>"; };
 		2482E35526A622CE003E070D /* AlbumDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumDTO.swift; sourceTree = "<group>"; };
 		847DE86026A9F2C800FF716B /* AlbumItemDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumItemDTO.swift; sourceTree = "<group>"; };
@@ -147,7 +147,7 @@
 		2482E34226A605AC003E070D /* Remote */ = {
 			isa = PBXGroup;
 			children = (
-				2482E34726A6090B003E070D /* SpotifyAccountRemote.swift */,
+				2482E34726A6090B003E070D /* SpotifyApiRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -246,7 +246,7 @@
 				8485290D26A8A541007FA6EA /* CategoriesAnswerDTO.swift in Sources */,
 				8485291526A9E918007FA6EA /* ImageObjectDTO.swift in Sources */,
 				8485291126A9E7B3007FA6EA /* SimplifiedArtistObjectDTO.swift in Sources */,
-				2482E34826A6090B003E070D /* SpotifyAccountRemote.swift in Sources */,
+				2482E34826A6090B003E070D /* SpotifyApiRemote.swift in Sources */,
 				847DE86F26AB264400FF716B /* FollowersObjectDTO.swift in Sources */,
 				2482E34626A6086E003E070D /* AlbumsAnswerDTO.swift in Sources */,
 				847DE86B26AB22C100FF716B /* PublicUserObjectDTO.swift in Sources */,

--- a/Sources/Modules/SpotifyApiModule/SpotifyApiModule/Remote/SpotifyApiRemote.swift
+++ b/Sources/Modules/SpotifyApiModule/SpotifyApiModule/Remote/SpotifyApiRemote.swift
@@ -21,6 +21,12 @@ public class SpotifyApiRemote: SpotifyApiService {
                                       , forKey: "Authorization")
     }
     
+    public func setAccessToken(_ token: AccessTokenDTO) {
+        self.accessToken = token
+        self.client.requestHttpHeaders.add(value: "\(accessToken.tokenType) \(accessToken.accessToken)"
+                                      , forKey: "Authorization")
+    }
+    
     public func getAllNewReleases(completion: @escaping (SearchResult) -> Void) {
         
         client.makeRequest(toURL: url.appendingPathComponent("browse/new-releases"), withHttpMethod: .get) { [weak self] result in

--- a/Sources/Modules/SpotifyApiModule/SpotifyApiModule/Remote/SpotifyApiRemote.swift
+++ b/Sources/Modules/SpotifyApiModule/SpotifyApiModule/Remote/SpotifyApiRemote.swift
@@ -17,12 +17,13 @@ public class SpotifyApiRemote: SpotifyApiService {
         self.url = url
         self.client = client
         self.accessToken = accessToken
-        self.client.requestHttpHeaders.add(value: "\(accessToken.tokenType) \(accessToken.accessToken)"
-                                      , forKey: "Authorization")
+        //self.client.requestHttpHeaders.add(value: "\(accessToken.tokenType) \(accessToken.accessToken)"
+        //                              , forKey: "Authorization")
     }
     
     public func setAccessToken(_ token: AccessTokenDTO) {
         self.accessToken = token
+        self.client.clearRequest()
         self.client.requestHttpHeaders.add(value: "\(accessToken.tokenType) \(accessToken.accessToken)"
                                       , forKey: "Authorization")
     }

--- a/Sources/Modules/SpotifyApiModule/SpotifyApiModule/Remote/SpotifyApiRemote.swift
+++ b/Sources/Modules/SpotifyApiModule/SpotifyApiModule/Remote/SpotifyApiRemote.swift
@@ -1,5 +1,5 @@
 //
-//  SpotifyAccountRemote.swift
+//  SpotifyApiRemote.swift
 //  SpotifyApiModule
 //
 //  Created by Christian Slanzi on 19.07.21.

--- a/Sources/Modules/SpotifyApiModule/SpotifyApiModule/SpotifyApiService.swift
+++ b/Sources/Modules/SpotifyApiModule/SpotifyApiModule/SpotifyApiService.swift
@@ -12,7 +12,7 @@ public protocol SpotifyApiService {
     
     typealias SearchResult = Swift.Result<AlbumsAnswerDTO, ServiceError>
 
-    //func setAccessToken(_ token: AccessTokenDTO)
+    func setAccessToken(_ token: AccessTokenDTO)
     func getAllNewReleases(completion: @escaping (SearchResult) -> Void)
     
     

--- a/Sources/SideProjectSpotifyApp.xcworkspace/contents.xcworkspacedata
+++ b/Sources/SideProjectSpotifyApp.xcworkspace/contents.xcworkspacedata
@@ -8,6 +8,9 @@
       location = "group:App/SideProjectSpotifyApp/../../Modules"
       name = "Modules">
       <FileRef
+         location = "group:SpotifyAccountApiModule/SpotifyAccountApiModule.xcodeproj">
+      </FileRef>
+      <FileRef
          location = "group:SpotifyApiModule/SpotifyApiModule.xcodeproj">
       </FileRef>
       <FileRef


### PR DESCRIPTION
add a framework module implementing the Spotify account apis to fetch a valid token

in the framework will be injected the app client id and client secret loaded from a Secrets.plist file
the Secrets.plist file must be created in the resource folder named "Secrets", a README file is present with detailed instructions
"Secrets.plist" has been added to the repository git ignore file, so that the secret keys won't be committed 

using the fetched token to make all Spotify api requests